### PR TITLE
Add s/S/x/X actions, various synonyms, mode hooks, userspace docs; optionally differentiate w & e motions; fix process hooks & redo on Mac; automate updating firmware size table in readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -150,7 +150,7 @@ Once you hit ~.~ it goes through the recorded keys until it hits normal mode aga
 The default size of the recorded keys buffer is =64=, but can be modified with the =VIM_REPEAT_BUF_SIZE= macro.
 
 *** W Motions
-If the =VIM_W_BEGINNING_OF_WORD= macro is defined, the ~w~ and ~W~ motions (which are synonymous) will skip to the beginning of the next word by sending LCTL + RIGHT and then tapping LCTL + RIGHT, LCTL + LEFT on release. Otherwise, their default behavior is to imitate the ~e~ and ~E~ motions by sending LCTL + RIGHT. Note that enabling this feature currently causes unexpected side effects with actions such as ~cw~ and ~dw~, as well as those involving ~i~ and ~a~ text objects such as ~viw~ and ~vaw~ ([[https://github.com/andrewjrae/qmk-vim/pull/1][context]]).
+If the =VIM_W_BEGINNING_OF_WORD= macro is defined, the ~w~ and ~W~ motions (which are synonymous) will skip to the beginning of the next word by sending LCTL + RIGHT and then tapping LCTL + RIGHT, LCTL + LEFT on release. Otherwise, their default behavior is to imitate the ~e~ and ~E~ motions by sending LCTL + RIGHT. Note that enabling this feature currently causes unexpected side effects with actions such as ~cw~ and ~dw~, as well as those involving ~i~ and ~a~ text objects such as ~viw~ and ~vaw~ ([[https://github.com/andrewjrae/qmk-vim/pull/1#discussion_r650416367][context]]).
 
 * Configuration
 ** Setup

--- a/README.org
+++ b/README.org
@@ -206,7 +206,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 }
   #+end_src
 ** Adding Keybinds
-Since most vim user's remap a key here or there, I've added hooks for the normal, visual, and insert modes.
+Since most vim users remap a key here or there, I've added hooks for the normal, visual, visual line, and insert modes.
 These hooks act in the exact same way that =process_record_user()= does, except that keycodes come in with any active modifiers applied to them.
 And not all keycodes will be passed down to vim, vim mode only intercepts keycodes alphanumeric, and symbolic keycodes (and escape).
 
@@ -215,9 +215,10 @@ It should also be noted that all modifiers will be added to the keycode as the l
 
 The hooks that you can use are:
 #+begin_src C
+bool process_insert_mode_user(uint16_t keycode, const keyrecord_t *record);
 bool process_normal_mode_user(uint16_t keycode, const keyrecord_t *record);
 bool process_visual_mode_user(uint16_t keycode, const keyrecord_t *record);
-bool process_insert_mode_user(uint16_t keycode, const keyrecord_t *record);
+bool process_visual_line_mode_user(uint16_t keycode, const keyrecord_t *record);
 #+end_src
 
 As an example, I have the bad habit of hitting ~CTRL+S~ all the time. And for a long time I've had it so that in insert mode, ~CTRL+S~ saves and enters [[#normal-mode][normal_mode()]].

--- a/README.org
+++ b/README.org
@@ -16,6 +16,7 @@
   - [[#extra-features][Extra Features]]
     - [[#text-objects][Text Objects]]
     - [[#dot-repeat][Dot Repeat]]
+    - [[#w-motions][W Motions]]
 - [[#configuration][Configuration]]
   - [[#setup][Setup]]
   - [[#adding-keybinds][Adding Keybinds]]
@@ -23,7 +24,7 @@
   -  [[#displaying-modes][Displaying Modes]]
 
 * About
-This is project aims to emulate as much of vim as possible in QMK userspace. The idea is to use clever combinations of shift, home, end, and control + arrow keys to emulate vim's modal editing and motions.
+This project aims to emulate as much of vim as possible in QMK userspace. The idea is to use clever combinations of shift, home, end, and control + arrow keys to emulate vim's modal editing and motions.
 
 The other goal is to make it relatively plug and play in user keymaps, while still providing customization options.
 
@@ -32,17 +33,17 @@ The other goal is to make it relatively plug and play in user keymaps, while sti
 The core features are in in the tables below and takes up roughly 5% of at Atmega32u4.
 *** Motions
 Motions are available in [[#normal-mode][normal]] and [[#visual-mode][visual mode]], and can be composed with [[#actions][actions]]. Note that in the table below the mods shown are for Linux/Windows, however if =VIM_FOR_MAC= is defined then these should change to =LOPT=.
-| Vim Binding | Action       | Notes                                                                             |
-|-------------+--------------+-----------------------------------------------------------------------------------|
-| h           | LEFT         |                                                                                   |
-| j           | DOWN         |                                                                                   |
-| k           | UP           |                                                                                   |
-| l           | RIGHT        |                                                                                   |
-| w / W       | LCTL + RIGHT | This may act more like an =e= command depending on the text environment           |
-| e / E       | LCTL + RIGHT | This may act more like an =e= command depending on the text environment           |
-| b / B       | LCTL + LEFT  |                                                                                   |
-| 0 / ^       | HOME         | In some text environments this goes to the true start, or the first piece of text |
-| $           | END          |                                                                                   |
+| Vim Binding | Action       | Notes                                                                                                                             |
+|-------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------|
+| h           | LEFT         |                                                                                                                                   |
+| j           | DOWN         |                                                                                                                                   |
+| k           | UP           |                                                                                                                                   |
+| l           | RIGHT        |                                                                                                                                   |
+| e / E       | LCTL + RIGHT | This may act more like a =w= command depending on the text environment                                                            |
+| w / W       | LCTL + RIGHT | By default, this may act more like an =e= command depending on the text environment. Alternatively, see [[#w-motions][W motions]] |
+| b / B       | LCTL + LEFT  |                                                                                                                                   |
+| 0 / ^       | HOME         | In some text environments this goes to the true start, or the first piece of text                                                 |
+| $           | END          |                                                                                                                                   |
 
 *** Actions
 Change, delete, and yank actions are all supported and can be combined with [[#motions][motions]] and text objects in normal mode as you would expect. For example =cw= will change until the next word (or end of word depending on your text environment). Note that by default the =d= action will copy the deleted text to the clipboard.
@@ -80,6 +81,7 @@ however if =VIM_FOR_MAC= is defined then these should change to =LCMD=.
 | u           | LCTL + z                                        | This works /most/ places                        |
 | CTRL + r    | LCTL + y                                        | This may or may not work everywhere             |
 | x           | DELETE                                          |                                                 |
+| X           | BACKSPACE                                       |                                                 |
 
 Note that all keycodes chorded with CTRL, GUI, or ALT, that aren't bound to anything are let through. In other words, you can still alt tab and use shortcuts for whatever editor you're in.
 
@@ -95,7 +97,7 @@ However, with =BETTER_VISUAL_MODE= enabled the first direction moved in visual m
 Of course this approach breaks down if you double back on the cursor, but I find I don't do that all that often.
 
 *** Visual Line Mode
-Visual line modes is very similar to [[#visual-mode][visual mode]] as you would expect however only the ~j~ and ~k~ motions are supported and of course the entire line is selected.
+Visual line mode is very similar to [[#visual-mode][visual mode]] as you would expect however only the ~j~ and ~k~ motions are supported and of course the entire line is selected.
 However, there is no perfect way (that I know of) to select lines the way vim does easily. The way I used do it before I used vim, was to get myself to the start of the line then hit shift and up or down.
 Going down works almost as you'd expect in vim, but you'll always be a line behind since it doesn't highlight the line the cursor is currently on.
 Going up on the other hand will select the line the cursor is on, but it will always be missing the first line.
@@ -110,27 +112,28 @@ Of course =BETTER_VISUAL_MODE= fixes this as long as you don't double back on th
 
 ** Extra Features
 In an effort to reduce the size overhead of the project, any extra features can be enabled and disabled using macros in your config.h.
-| Macro                 | Features Enabled/Disabled                                                                                              | Bytes (avr-gcc 8.3.0) |
-|-----------------------+------------------------------------------------------------------------------------------------------------------------+-----------------------|
-| =NO_VISUAL_MODE=      | Disables the normal visual mode.                                                                                       | +204 B                |
-| =NO_VISUAL_LINE_MODE= | Disables the normal visual line mode.                                                                                  | +222 B                |
-| =BETTER_VISUAL_MODE=  | Makes the visual modes much more vim like, see [[#visual-line-mode][visual_line_mode()]] for details.                  | -196 B                |
-| =VIM_I_TEXT_OBJECTS=  | Adds the ~i~ text objects, which adds the ~iw~ and ~ig~ text objects, see [[#text-objects][text objects]] for details. | -78 B                 |
-| =VIM_A_TEXT_OBJECTS=  | Adds the ~a~ text objects, which adds the ~aw~ and ~ag~ text objects.                                                  | -94 B                 |
-| =VIM_G_MOTIONS=       | Adds ~gg~ and ~G~ motions, which only work in some programs.                                                           | -118 B                |
-| =VIM_COLON_CMDS=      | Adds the colon command state, but only the ~w~ and ~q~ commands are supported (can be in combination).                 | -68 B                 |
-| =VIM_PASTE_BEFORE=    | Adds the ~P~ command.                                                                                                  | -38 B                 |
-| =VIM_REPLACE=         | Adds the ~r~ command.                                                                                                  | -62 B                 |
-| =VIM_DOT_REPEAT=      | Adds the ~.~ command, allowing you to repeat actions, see [[#dot-repeat][dot repeat]] for details.                     | -212 B                |
+| Macro                     | Features Enabled/Disabled                                                                                              | Bytes (avr-gcc 8.3.0) |
+|---------------------------+------------------------------------------------------------------------------------------------------------------------+-----------------------|
+| =NO_VISUAL_MODE=          | Disables the normal visual mode.                                                                                       | +204 B                |
+| =NO_VISUAL_LINE_MODE=     | Disables the normal visual line mode.                                                                                  | +222 B                |
+| =BETTER_VISUAL_MODE=      | Makes the visual modes much more vim like, see [[#visual-line-mode][visual_line_mode()]] for details.                  | -196 B                |
+| =VIM_I_TEXT_OBJECTS=      | Adds the ~i~ text objects, which adds the ~iw~ and ~ig~ text objects, see [[#text-objects][text objects]] for details. | -78 B                 |
+| =VIM_A_TEXT_OBJECTS=      | Adds the ~a~ text objects, which adds the ~aw~ and ~ag~ text objects.                                                  | -94 B                 |
+| =VIM_G_MOTIONS=           | Adds ~gg~ and ~G~ motions, which only work in some programs.                                                           | -118 B                |
+| =VIM_COLON_CMDS=          | Adds the colon command state, but only the ~w~ and ~q~ commands are supported (can be in combination).                 | -68 B                 |
+| =VIM_PASTE_BEFORE=        | Adds the ~P~ command.                                                                                                  | -38 B                 |
+| =VIM_REPLACE=             | Adds the ~r~ command.                                                                                                  | -62 B                 |
+| =VIM_DOT_REPEAT=          | Adds the ~.~ command, allowing you to repeat actions, see [[#dot-repeat][dot repeat]] for details.                     | -212 B                |
+| =VIM_W_BEGINNING_OF_WORD= | Makes the ~w~ and ~W~ motions skip to the beginning of the next word, see [[#w-motions][W motions]] for details.       | TODO                  |
 
 With all the extra features enabled, the firmware takes up 1842 B of space which is roughly 6% of a pro-micro.
 
 *** Text Objects
-Unfortunately there is really no way to implement text objects properly, especially things like brackets. However, word objects are very possible in some form are quite possible.
+Unfortunately there is really no way to implement text objects properly, especially things like brackets. However, word objects in some form are quite possible.
 The tricky part is distinguishing between an inner and outer word, some editors will have a forward word jump go to the end of a word like vim's ~e~, while others will go to the start of the next, like vim's ~w~.
 
 It's easy to get an inner word if word jump acts like ~e~, since you can go to the end of the word, then hold shift and jump to the start.
-And similarly it's easy to get an outre word if word jump acts like ~w~, since you can go the start of the next word then hold shift and jump back to the start of your word.
+And similarly it's easy to get an outer word if word jump acts like ~w~, since you can go to the start of the next word then hold shift and jump back to the start of your word.
 However, getting an inner word with just ~w~ and ~b~ at your disposal isn't possible without using arrow keys which won't be consistent in scenarios where the word punctuated in some way.
 But, it is possible to get an outer word with ~b~ and ~e~. In vim terms, the sequence looks like ~eebvb~, now in vim that doesn't do exactly what we want, but with word jumps it does result in an outer word selection.
 
@@ -145,6 +148,9 @@ For example, typing ~ciw~, ~hello!~, will replace the underlying word with ~hell
 The way this works is that once an action starts, like ~c~ or ~D~, or even ~A~ all keycodes are recorded until we return to the normal mode state.
 Once you hit ~.~ it goes through the recorded keys until it hits normal mode again.
 The default size of the recorded keys buffer is =64=, but can be modified with the =VIM_REPEAT_BUF_SIZE= macro.
+
+*** W Motions
+If the =VIM_W_BEGINNING_OF_WORD= macro is defined, the ~w~ and ~W~ motions (which are synonymous) will skip to the beginning of the next word by sending LCTL + RIGHT and then tapping LCTL + RIGHT, LCTL + LEFT on release. Otherwise, their default behavior is to imitate the ~e~ and ~E~ motions by sending LCTL + RIGHT. Note that enabling this feature currently causes unexpected side effects with actions such as ~cw~ and ~dw~, as well as those involving ~i~ and ~a~ text objects such as ~viw~ and ~vaw~ ([[https://github.com/andrewjrae/qmk-vim/pull/1][context]]).
 
 * Configuration
 ** Setup

--- a/README.org
+++ b/README.org
@@ -232,6 +232,24 @@ bool process_insert_mode_user(uint16_t keycode, const keyrecord_t *record) {
     return true;
 }
 #+end_src
+** Setting Custom State
+The following user hooks are also called whenever the active mode is changed:
+#+begin_src C
+void insert_mode_user(void);
+void normal_mode_user(void);
+void visual_mode_user(void);
+void visual_line_mode_user(void);
+#+end_src
+
+These can optionally be used to set custom state in your keymap.c file; for example, changing the [[https://beta.docs.qmk.fm/using-qmk/hardware-features/lighting/feature_rgblight#enabling-and-disabling-lighting-layers-id-enabling-lighting-layers][RGB lighting layer]] to indicate the current mode:
+#+begin_src C
+void insert_mode_user(void) {
+  rgblight_set_layer_state(VIM_LIGHTING_LAYER, false);
+}
+void normal_mode_user(void) {
+  rgblight_set_layer_state(VIM_LIGHTING_LAYER, true);
+}
+#+end_src
 ** Mac Support
 Since Macs have different shortcuts, you need to set the =VIM_FOR_MAC= macro in your config.h.
 That being said I'm not a Mac user so it's all untested and I'd guess there are some issues.

--- a/README.org
+++ b/README.org
@@ -38,10 +38,10 @@ Motions are available in [[#normal-mode][normal]] and [[#visual-mode][visual mod
 | j           | DOWN                                    |                                                                                   |
 | k           | UP                                      |                                                                                   |
 | l           | RIGHT                                   |                                                                                   |
-| w           | LCTL + RIGHT, LCTL + RIGHT, LCTL + LEFT |                                                                                   |
-| e           | LCTL + RIGHT                            |                                                                                   |
-| b           | LCTL + LEFT                             |                                                                                   |
-| 0           | HOME                                    | In some text environments this goes to the true start, or the first piece of text |
+| w / W       | LCTL + RIGHT, LCTL + RIGHT, LCTL + LEFT |                                                                                   |
+| e / E       | LCTL + RIGHT                            |                                                                                   |
+| b / B       | LCTL + LEFT                             |                                                                                   |
+| 0 / ^       | HOME                                    | In some text environments this goes to the true start, or the first piece of text |
 | $           | END                                     |                                                                                   |
 
 *** Actions

--- a/README.org
+++ b/README.org
@@ -79,7 +79,7 @@ however if =VIM_FOR_MAC= is defined then these should change to =LCMD=.
 | p           | [[#paste-action][paste_action()]]               |                                                 |
 | u           | LCTL + z                                        | This works /most/ places                        |
 | CTRL + r    | LCTL + y                                        | This may or may not work everywhere             |
-| x           | DELETE                                          | This is currently only supported in normal mode |
+| x           | DELETE                                          |                                                 |
 
 Note that all keycodes chorded with CTRL, GUI, or ALT, that aren't bound to anything are let through. In other words, you can still alt tab and use shortcuts for whatever editor you're in.
 

--- a/README.org
+++ b/README.org
@@ -50,14 +50,15 @@ Change, delete, and yank actions are all supported and can be combined with [[#m
 In visual mode each action can be accessed with =c=, =d=, and =y= respectively and they will act on the currently selected visual area.
 
 Normal mode also supports these commands:
-| Vim Binding | Action                | Notes                                              |
-|-------------+-----------------------+----------------------------------------------------|
-| cc          | Change line           | This doesn't copy the old line to clipboard        |
-| C           | Change to end of line | This doesn't copy the changed content to clipboard |
-| dd          | Delete line           | This copies the deleted line to clipboard          |
-| D           | Delete to end of line | This copies the deleted text to clipboard          |
-| yy          | Yank line             |                                                    |
-| Y           | Yank to end of line   |                                                    |
+| Vim Binding | Action                              | Notes                                              |
+|-------------+-------------------------------------+----------------------------------------------------|
+| cc / S      | Change line                         | This doesn't copy the old line to clipboard        |
+| C           | Change to end of line               | This doesn't copy the changed content to clipboard |
+| s           | Change character to right of cursor | This doesn't copy the changed content to clipboard |
+| dd          | Delete line                         | This copies the deleted line to clipboard          |
+| D           | Delete to end of line               | This copies the deleted text to clipboard          |
+| yy          | Yank line                           |                                                    |
+| Y           | Yank to end of line                 |                                                    |
 
 **** Paste Action
 The =paste_action()= handles pasting, which is simple for non lines, but most of the time, I'm pasting lines so this function attempts to consistently handle pasting lines. Yanks and deletes of lines are tracked through the =yanked_line= global, the paste action then pastes accordingly. For copying and pasting lines the line(s) the selection is made from the very start of the line below, up to start of the first line. See the [[#visual-line-mode][visual line mode]] section for more info on how lines are selected. There is also an optional =paste_before_action()=, enabled with the =VIM_PASTE_BEFORE= macro.
@@ -147,14 +148,18 @@ The default size of the recorded keys buffer is =64=, but can be modified with t
 
 * Configuration
 ** Setup
-+ First add the repo as a submodule to your keymap.
++ First add the repo as a submodule to your keymap or userspace.
   #+begin_src bash
 git submodule add https://github.com/andrewjrae/qmk-vim.git
   #+end_src
 
-+ Next, you need source the files in the make file, the easy way to do this is to just add this line to your ~rules.mk~ file.
++ Next, you need to source the files in the make file, the easy way to do this is to just add this line to your keymap's ~rules.mk~ file:
   #+begin_src make
 include $(KEYBOARD_PATH_2)/keymaps/$(KEYMAP)/qmk-vim/rules.mk
+  #+end_src
+  ...or to your userspace's ~rules.mk~ file:
+  #+begin_src make
+include $(USER_PATH)/qmk-vim/rules.mk
   #+end_src
   If this doesn't work, you can either try changing the number in the =KEYBOARD_PATH_2= variable (values 1-5), or simply copy the contents from [[file:rules.mk][qmk-vim/rules.mk]].
 

--- a/README.org
+++ b/README.org
@@ -32,17 +32,17 @@ The other goal is to make it relatively plug and play in user keymaps, while sti
 The core features are in in the tables below and takes up roughly 5% of at Atmega32u4.
 *** Motions
 Motions are available in [[#normal-mode][normal]] and [[#visual-mode][visual mode]], and can be composed with [[#actions][actions]]. Note that in the table below the mods shown are for Linux/Windows, however if =VIM_FOR_MAC= is defined then these should change to =LOPT=.
-| Vim Binding | Action       | Notes                                                                             |
-|-------------+--------------+-----------------------------------------------------------------------------------|
-| h           | LEFT         |                                                                                   |
-| j           | DOWN         |                                                                                   |
-| k           | UP           |                                                                                   |
-| l           | RIGHT        |                                                                                   |
-| w           | LCTL + RIGHT | This may act more like an =e= command depending on the text environment             |
-| e           | LCTL + RIGHT | This may act more like an =w= command depending on the text environment             |
-| b           | LCTL + LEFT  |                                                                                   |
-| 0           | HOME         | In some text environments this goes to the true start, or the first piece of text |
-| $           | END          |                                                                                   |
+| Vim Binding | Action                                  | Notes                                                                             |
+|-------------+-----------------------------------------+-----------------------------------------------------------------------------------|
+| h           | LEFT                                    |                                                                                   |
+| j           | DOWN                                    |                                                                                   |
+| k           | UP                                      |                                                                                   |
+| l           | RIGHT                                   |                                                                                   |
+| w           | LCTL + RIGHT, LCTL + RIGHT, LCTL + LEFT |                                                                                   |
+| e           | LCTL + RIGHT                            |                                                                                   |
+| b           | LCTL + LEFT                             |                                                                                   |
+| 0           | HOME                                    | In some text environments this goes to the true start, or the first piece of text |
+| $           | END                                     |                                                                                   |
 
 *** Actions
 Change, delete, and yank actions are all supported and can be combined with [[#motions][motions]] and text objects in normal mode as you would expect. For example =cw= will change until the next word (or end of word depending on your text environment). Note that by default the =d= action will copy the deleted text to the clipboard.

--- a/README.org
+++ b/README.org
@@ -32,17 +32,17 @@ The other goal is to make it relatively plug and play in user keymaps, while sti
 The core features are in in the tables below and takes up roughly 5% of at Atmega32u4.
 *** Motions
 Motions are available in [[#normal-mode][normal]] and [[#visual-mode][visual mode]], and can be composed with [[#actions][actions]]. Note that in the table below the mods shown are for Linux/Windows, however if =VIM_FOR_MAC= is defined then these should change to =LOPT=.
-| Vim Binding | Action                                  | Notes                                                                             |
-|-------------+-----------------------------------------+-----------------------------------------------------------------------------------|
-| h           | LEFT                                    |                                                                                   |
-| j           | DOWN                                    |                                                                                   |
-| k           | UP                                      |                                                                                   |
-| l           | RIGHT                                   |                                                                                   |
-| w / W       | LCTL + RIGHT, LCTL + RIGHT, LCTL + LEFT |                                                                                   |
-| e / E       | LCTL + RIGHT                            |                                                                                   |
-| b / B       | LCTL + LEFT                             |                                                                                   |
-| 0 / ^       | HOME                                    | In some text environments this goes to the true start, or the first piece of text |
-| $           | END                                     |                                                                                   |
+| Vim Binding | Action       | Notes                                                                             |
+|-------------+--------------+-----------------------------------------------------------------------------------|
+| h           | LEFT         |                                                                                   |
+| j           | DOWN         |                                                                                   |
+| k           | UP           |                                                                                   |
+| l           | RIGHT        |                                                                                   |
+| w / W       | LCTL + RIGHT | This may act more like an =e= command depending on the text environment           |
+| e / E       | LCTL + RIGHT | This may act more like an =e= command depending on the text environment           |
+| b / B       | LCTL + LEFT  |                                                                                   |
+| 0 / ^       | HOME         | In some text environments this goes to the true start, or the first piece of text |
+| $           | END          |                                                                                   |
 
 *** Actions
 Change, delete, and yank actions are all supported and can be combined with [[#motions][motions]] and text objects in normal mode as you would expect. For example =cw= will change until the next word (or end of word depending on your text environment). Note that by default the =d= action will copy the deleted text to the clipboard.

--- a/README.org
+++ b/README.org
@@ -21,7 +21,9 @@
   - [[#setup][Setup]]
   - [[#adding-keybinds][Adding Keybinds]]
   - [[#mac-support][Mac Support]]
-  -  [[#displaying-modes][Displaying Modes]]
+  - [[#displaying-modes][Displaying Modes]]
+- [[#contributing][Contributing]]
+  - [[#updating-readme-firmware-sizes][Updating Readme Firmware Sizes]]
 
 * About
 This project aims to emulate as much of vim as possible in QMK userspace. The idea is to use clever combinations of shift, home, end, and control + arrow keys to emulate vim's modal editing and motions.
@@ -112,21 +114,19 @@ Of course =BETTER_VISUAL_MODE= fixes this as long as you don't double back on th
 
 ** Extra Features
 In an effort to reduce the size overhead of the project, any extra features can be enabled and disabled using macros in your config.h.
-| Macro                     | Features Enabled/Disabled                                                                                              | Bytes (avr-gcc 8.3.0) |
-|---------------------------+------------------------------------------------------------------------------------------------------------------------+-----------------------|
-| =NO_VISUAL_MODE=          | Disables the normal visual mode.                                                                                       | +204 B                |
-| =NO_VISUAL_LINE_MODE=     | Disables the normal visual line mode.                                                                                  | +222 B                |
-| =BETTER_VISUAL_MODE=      | Makes the visual modes much more vim like, see [[#visual-line-mode][visual_line_mode()]] for details.                  | -196 B                |
-| =VIM_I_TEXT_OBJECTS=      | Adds the ~i~ text objects, which adds the ~iw~ and ~ig~ text objects, see [[#text-objects][text objects]] for details. | -78 B                 |
-| =VIM_A_TEXT_OBJECTS=      | Adds the ~a~ text objects, which adds the ~aw~ and ~ag~ text objects.                                                  | -94 B                 |
-| =VIM_G_MOTIONS=           | Adds ~gg~ and ~G~ motions, which only work in some programs.                                                           | -118 B                |
-| =VIM_COLON_CMDS=          | Adds the colon command state, but only the ~w~ and ~q~ commands are supported (can be in combination).                 | -68 B                 |
-| =VIM_PASTE_BEFORE=        | Adds the ~P~ command.                                                                                                  | -38 B                 |
-| =VIM_REPLACE=             | Adds the ~r~ command.                                                                                                  | -62 B                 |
-| =VIM_DOT_REPEAT=          | Adds the ~.~ command, allowing you to repeat actions, see [[#dot-repeat][dot repeat]] for details.                     | -212 B                |
-| =VIM_W_BEGINNING_OF_WORD= | Makes the ~w~ and ~W~ motions skip to the beginning of the next word, see [[#w-motions][W motions]] for details.       | TODO                  |
-
-With all the extra features enabled, the firmware takes up 1842 B of space which is roughly 6% of a pro-micro.
+| Macro                     | Features Enabled/Disabled                                                                                              | Bytes (gcc 8.3.0) |
+|---------------------------+------------------------------------------------------------------------------------------------------------------------+-------------------|
+| =NO_VISUAL_MODE=          | Disables the normal visual mode.                                                                                       | +256 B            |
+| =NO_VISUAL_LINE_MODE=     | Disables the normal visual line mode.                                                                                  | +336 B            |
+| =BETTER_VISUAL_MODE=      | Makes the visual modes much more vim like, see [[#visual-line-mode][visual_line_mode()]] for details.                  | -174 B            |
+| =VIM_I_TEXT_OBJECTS=      | Adds the ~i~ text objects, which adds the ~iw~ and ~ig~ text objects, see [[#text-objects][text objects]] for details. | -108 B            |
+| =VIM_A_TEXT_OBJECTS=      | Adds the ~a~ text objects, which adds the ~aw~ and ~ag~ text objects.                                                  | -124 B            |
+| =VIM_G_MOTIONS=           | Adds ~gg~ and ~G~ motions, which only work in some programs.                                                           | -116 B            |
+| =VIM_COLON_CMDS=          | Adds the colon command state, but only the ~w~ and ~q~ commands are supported (can be in combination).                 | -72 B             |
+| =VIM_PASTE_BEFORE=        | Adds the ~P~ command.                                                                                                  | -60 B             |
+| =VIM_REPLACE=             | Adds the ~r~ command.                                                                                                  | -70 B             |
+| =VIM_DOT_REPEAT=          | Adds the ~.~ command, allowing you to repeat actions, see [[#dot-repeat][dot repeat]] for details.                     | -232 B            |
+| =VIM_W_BEGINNING_OF_WORD= | Makes the ~w~ and ~W~ motions skip to the beginning of the next word, see [[#w-motions][W motions]] for details.       | -84 B             |
 
 *** Text Objects
 Unfortunately there is really no way to implement text objects properly, especially things like brackets. However, word objects in some form are quite possible.
@@ -287,4 +287,12 @@ if (vim_mode_enabled()) {
             oled_write_P(PSTR("?????\n"), false);
             break;
     }
+#+end_src
+
+* Contributing
+** Updating Readme Firmware Sizes
+If you'd like to submit a pull request, please update the [[#extra-features][table with the firmware sizes for each feature]]. This can be done automatically by running the following commands in the root directory of this repository (it may take a few minutes, since it recompiles for each feature in the table):
+#+begin_src bash
+docker build -t qmk-vim-update-readme update-readme
+docker run -v $PWD:/qmk_firmware/keyboards/uno/keymaps/qmk-vim-update-readme/qmk-vim qmk-vim-update-readme
 #+end_src

--- a/src/actions.c
+++ b/src/actions.c
@@ -66,21 +66,27 @@ static bool process_vim_action(uint16_t keycode, const keyrecord_t *record) {
 
 #ifdef VIM_I_TEXT_OBJECTS
 static bool process_in_object(uint16_t keycode, const keyrecord_t *record) {
-    if (record->event.pressed) {
-        switch (keycode) {
-            case KC_W:
+    switch (keycode) {
+        case KC_W:
+            if (record->event.pressed) {
                 tap_code16(VIM_W);
                 tap_code16(LSFT(VIM_B));
+            } else {
                 action_func();
-                return false;
-            case KC_G:
+            }
+            return false;
+        case KC_G:
+            if (record->event.pressed) {
                 tap_code16(VCMD(KC_A));
+            } else {
                 action_func();
-                return false;
-            default:
+            }
+            return false;
+        default:
+            if (record->event.pressed) {
                 normal_mode();
-                return false;
-        }
+            }
+            return false;
     }
     return false;
 }

--- a/src/actions.c
+++ b/src/actions.c
@@ -66,27 +66,21 @@ static bool process_vim_action(uint16_t keycode, const keyrecord_t *record) {
 
 #ifdef VIM_I_TEXT_OBJECTS
 static bool process_in_object(uint16_t keycode, const keyrecord_t *record) {
-    switch (keycode) {
-        case KC_W:
-            if (record->event.pressed) {
+    if (record->event.pressed) {
+        switch (keycode) {
+            case KC_W:
                 tap_code16(VIM_W);
                 tap_code16(LSFT(VIM_B));
-            } else {
                 action_func();
-            }
-            return false;
-        case KC_G:
-            if (record->event.pressed) {
+                return false;
+            case KC_G:
                 tap_code16(VCMD(KC_A));
-            } else {
                 action_func();
-            }
-            return false;
-        default:
-            if (record->event.pressed) {
+                return false;
+            default:
                 normal_mode();
-            }
-            return false;
+                return false;
+        }
     }
     return false;
 }

--- a/src/actions.h
+++ b/src/actions.h
@@ -7,20 +7,19 @@
 // This should be used whenever using one of these shortcuts
 #ifdef VIM_FOR_MAC
 #define VCMD LCMD
-#define VIM_REDO_KEYCODE LSFT(KC_Z)
+#define VIM_REDO VCMD(LSFT(KC_Z))
 #else
 #define VCMD LCTL
-#define VIM_REDO_KEYCODE KC_Y
+#define VIM_REDO VCMD(KC_Y)
 #endif
 
-// These are the main keys for each vim core vim action
+// These + VIM_REDO (defined above) are the main keys for each vim core vim action
 #define VIM_CHANGE KC_DEL
 #define VIM_DELETE VCMD(KC_X) // note that you may prefer a simple delete here since we only are using one clipboard
 #define VIM_YANK VCMD(KC_C)
 // Other commands
 #define VIM_PASTE VCMD(KC_V)
 #define VIM_UNDO VCMD(KC_Z)
-#define VIM_REDO VCMD(VIM_REDO_KEYCODE)
 #define VIM_FIND VCMD(KC_F)
 #define VIM_SAVE VCMD(KC_S)
 #define VIM_X KC_DEL

--- a/src/actions.h
+++ b/src/actions.h
@@ -23,6 +23,7 @@
 #define VIM_FIND VCMD(KC_F)
 #define VIM_SAVE VCMD(KC_S)
 #define VIM_X KC_DEL
+#define VIM_SHIFT_X KC_BSPC
 
 // Process function to handle text objects ie in or around word
 bool process_text_objects(uint16_t keycode, const keyrecord_t *record);

--- a/src/actions.h
+++ b/src/actions.h
@@ -18,7 +18,11 @@
 // Other commands
 #define VIM_PASTE VCMD(KC_V)
 #define VIM_UNDO VCMD(KC_Z)
+#ifdef VIM_FOR_MAC
+#define VIM_REDO VCMD(S(KC_Z))
+#else
 #define VIM_REDO VCMD(KC_Y)
+#endif
 #define VIM_FIND VCMD(KC_F)
 #define VIM_SAVE VCMD(KC_S)
 #define VIM_X KC_DEL

--- a/src/actions.h
+++ b/src/actions.h
@@ -7,8 +7,10 @@
 // This should be used whenever using one of these shortcuts
 #ifdef VIM_FOR_MAC
 #define VCMD LCMD
+#define VIM_REDO_KEYCODE LSFT(KC_Z)
 #else
 #define VCMD LCTL
+#define VIM_REDO_KEYCODE KC_Y
 #endif
 
 // These are the main keys for each vim core vim action
@@ -18,11 +20,7 @@
 // Other commands
 #define VIM_PASTE VCMD(KC_V)
 #define VIM_UNDO VCMD(KC_Z)
-#ifdef VIM_FOR_MAC
-#define VIM_REDO VCMD(S(KC_Z))
-#else
-#define VIM_REDO VCMD(KC_Y)
-#endif
+#define VIM_REDO VCMD(VIM_REDO_KEYCODE)
 #define VIM_FIND VCMD(KC_F)
 #define VIM_SAVE VCMD(KC_S)
 #define VIM_X KC_DEL

--- a/src/modes.c
+++ b/src/modes.c
@@ -223,7 +223,7 @@ bool process_normal_mode(uint16_t keycode, const keyrecord_t *record) {
     return false;
 }
 
-// Allow the user to add their own bindings to both visual modes
+// Allow the user to add their own bindings to visual mode
 // Note, this should be optimized away unless there is a user definition
 __attribute__ ((weak))
 bool process_visual_mode_user(uint16_t keycode, const keyrecord_t *record) {
@@ -282,8 +282,18 @@ bool process_visual_mode(uint16_t keycode, const keyrecord_t *record) {
     return false;
 }
 
+// Allow the user to add their own bindings to visual line mode
+// Note, this should be optimized away unless there is a user definition
+__attribute__ ((weak))
+bool process_visual_line_mode_user(uint16_t keycode, const keyrecord_t *record) {
+    return true;
+}
+
 // The function that handles visual line mode keycode inputs
 bool process_visual_line_mode(uint16_t keycode, const keyrecord_t *record) {
+    if (!process_visual_line_mode_user(keycode, record)) {
+        return false;
+    }
     // handle motions on their own so they can be pressed and held
     switch (keycode) {
         case KC_J:

--- a/src/modes.c
+++ b/src/modes.c
@@ -181,6 +181,9 @@ bool process_normal_mode(uint16_t keycode, const keyrecord_t *record) {
             case KC_X:
                 tap_code16(VIM_X);
                 break;
+            case LSFT(KC_X):
+                tap_code16(VIM_SHIFT_X);
+                break;
 #ifdef VIM_COLON_CMDS
             case KC_COLON:
                 process_func = process_colon_cmd;

--- a/src/modes.c
+++ b/src/modes.c
@@ -120,6 +120,15 @@ bool process_normal_mode(uint16_t keycode, const keyrecord_t *record) {
             case KC_D:
                 start_delete_action();
                 break;
+            case LSFT(KC_S):
+                VIM_HOME();
+                VIM_SHIFT_END();
+                change_action();
+                break;
+            case KC_S:
+                tap_code16(LSFT(KC_RIGHT));
+                change_action();
+                break;
             case LSFT(KC_Y):
                 VIM_SHIFT_END();
                 yank_action();
@@ -232,6 +241,7 @@ bool process_visual_mode(uint16_t keycode, const keyrecord_t *record) {
     if (record->event.pressed) {
         switch (keycode) {
             case KC_C:
+            case KC_S:
                 change_action();
                 return false;
             case KC_D:
@@ -289,6 +299,7 @@ bool process_visual_line_mode(uint16_t keycode, const keyrecord_t *record) {
     if (record->event.pressed) {
         switch (keycode) {
             case KC_C:
+            case KC_S:
                 tap_code16(LSFT(KC_LEFT));
                 change_action();
                 return false;

--- a/src/modes.c
+++ b/src/modes.c
@@ -245,6 +245,7 @@ bool process_visual_mode(uint16_t keycode, const keyrecord_t *record) {
                 change_action();
                 return false;
             case KC_D:
+            case KC_X:
                 delete_action();
                 return false;
             case KC_Y:
@@ -304,6 +305,7 @@ bool process_visual_line_mode(uint16_t keycode, const keyrecord_t *record) {
                 change_action();
                 return false;
             case KC_D:
+            case KC_X:
                 delete_line_action();
                 return false;
             case KC_Y:

--- a/src/modes.c
+++ b/src/modes.c
@@ -350,22 +350,40 @@ bool process_insert_mode(uint16_t keycode, const keyrecord_t *record) {
 }
 
 
+// Allow the user to set custom state when normal mode is entered
+__attribute__ ((weak))
+void normal_mode_user(void) {
+}
+
 // Function to enter into normal mode
 void normal_mode(void) {
+    normal_mode_user();
     vim_current_mode = NORMAL_MODE;
     process_func = process_normal_mode;
 }
 
+// Allow the user to set custom state when insert mode is entered
+__attribute__ ((weak))
+void insert_mode_user(void) {
+}
+
 // Function to enter into insert mode
 void insert_mode(void) {
+    insert_mode_user();
     vim_current_mode = INSERT_MODE;
     // need to clear motion keys if they are currently pressed
     clear_keyboard();
     process_func = process_insert_mode;
 }
 
+// Allow the user to set custom state when visual mode is entered
+__attribute__ ((weak))
+void visual_mode_user(void) {
+}
+
 // Function to enter into visual mode
 void visual_mode(void) {
+    visual_mode_user();
     vim_current_mode = VISUAL_MODE;
 #ifndef NO_VISUAL_MODE
 #ifdef BETTER_VISUAL_MODE
@@ -378,8 +396,14 @@ void visual_mode(void) {
 }
 
 
+// Allow the user to set custom state when visual line mode is entered
+__attribute__ ((weak))
+void visual_line_mode_user(void) {
+}
+
 // Function to enter into visual line mode
 void visual_line_mode(void) {
+    visual_line_mode_user();
     vim_current_mode = VISUAL_LINE_MODE;
 #ifndef NO_VISUAL_LINE_MODE
 #ifdef BETTER_VISUAL_MODE

--- a/src/modes.c
+++ b/src/modes.c
@@ -66,6 +66,9 @@ bool process_normal_mode_user(uint16_t keycode, const keyrecord_t *record) {
 
 // The function that handles normal mode keycode inputs
 bool process_normal_mode(uint16_t keycode, const keyrecord_t *record) {
+    if (!process_normal_mode_user(keycode, record)) {
+        return false;
+    }
 #ifdef VIM_DOT_REPEAT
     bool should_record_action = true;
     #define NO_RECORD_ACTION() should_record_action = false;
@@ -229,6 +232,9 @@ bool process_visual_mode_user(uint16_t keycode, const keyrecord_t *record) {
 
 // The function that handles visual mode keycode inputs
 bool process_visual_mode(uint16_t keycode, const keyrecord_t *record) {
+    if (!process_visual_mode_user(keycode, record)) {
+        return false;
+    }
     // handle motions on their own so they can be pressed and held
     if (!process_motions(keycode, record, QK_LSFT)) {
         return false;

--- a/src/motions.c
+++ b/src/motions.c
@@ -46,11 +46,16 @@ bool process_motions(uint16_t keycode, const keyrecord_t *record, uint16_t qk_mo
             set_visual_direction(V_BACKWARD);
             register_motion(qk_mods | VIM_B, record);
             return false;
-        case KC_E: // currently this doesn't do much
+        case KC_E:
+            set_visual_direction(V_FORWARD);
+            register_motion(qk_mods | VIM_E, record);
+            return false;
         case KC_W:
         case VIM_W:
             set_visual_direction(V_FORWARD);
             register_motion(qk_mods | VIM_W, record);
+            register_motion(qk_mods | VIM_W, record);
+            register_motion(qk_mods | VIM_B, record);
             return false;
         case KC_0:
         case VIM_0:

--- a/src/motions.c
+++ b/src/motions.c
@@ -49,20 +49,11 @@ bool process_motions(uint16_t keycode, const keyrecord_t *record, uint16_t qk_mo
             return false;
         case KC_E:
         case LSFT(KC_E):
-            set_visual_direction(V_FORWARD);
-            register_motion(qk_mods | VIM_E, record);
-            return false;
         case KC_W:
         case VIM_W:
         case LSFT(KC_W):
             set_visual_direction(V_FORWARD);
-            if (record->event.pressed) {
-              register_code16(qk_mods | VIM_W);
-            } else {
-              unregister_code16(qk_mods | VIM_W);
-              tap_code16(qk_mods | VIM_W);
-              tap_code16(qk_mods | VIM_B);
-            }
+            register_motion(qk_mods | VIM_W, record);
             return false;
         case KC_0:
         case VIM_0:

--- a/src/motions.c
+++ b/src/motions.c
@@ -43,15 +43,18 @@ bool process_motions(uint16_t keycode, const keyrecord_t *record, uint16_t qk_mo
             return false;
         case KC_B:
         case VIM_B:
+        case LSFT(KC_B):
             set_visual_direction(V_BACKWARD);
             register_motion(qk_mods | VIM_B, record);
             return false;
         case KC_E:
+        case LSFT(KC_E):
             set_visual_direction(V_FORWARD);
             register_motion(qk_mods | VIM_E, record);
             return false;
         case KC_W:
         case VIM_W:
+        case LSFT(KC_W):
             set_visual_direction(V_FORWARD);
             if (record->event.pressed) {
               register_code16(qk_mods | VIM_W);

--- a/src/motions.c
+++ b/src/motions.c
@@ -47,21 +47,32 @@ bool process_motions(uint16_t keycode, const keyrecord_t *record, uint16_t qk_mo
             set_visual_direction(V_BACKWARD);
             register_motion(qk_mods | VIM_B, record);
             return false;
-        case KC_E:
-        case LSFT(KC_E):
         case KC_W:
         case VIM_W:
         case LSFT(KC_W):
+#ifdef VIM_W_BEGINNING_OF_WORD
             set_visual_direction(V_FORWARD);
-            register_motion(qk_mods | VIM_W, record);
+            if (record->event.pressed) {
+              register_code16(qk_mods | VIM_W);
+            } else {
+              unregister_code16(qk_mods | VIM_W);
+              tap_code16(qk_mods | VIM_W);
+              tap_code16(qk_mods | VIM_B);
+            }
+            return false;
+#endif
+        case KC_E:
+        case LSFT(KC_E):
+            set_visual_direction(V_FORWARD);
+            register_motion(qk_mods | VIM_E, record);
             return false;
         case KC_0:
         case VIM_0:
-        case KC_CIRC:
+        case KC_CIRC: // ^
             set_visual_direction(V_BACKWARD);
             register_motion(qk_mods | VIM_0, record);
             return false;
-        case KC_DLR:
+        case KC_DLR: // $
         case VIM_DLR:
             set_visual_direction(V_FORWARD);
             register_motion(qk_mods | VIM_DLR, record);

--- a/src/motions.c
+++ b/src/motions.c
@@ -53,9 +53,13 @@ bool process_motions(uint16_t keycode, const keyrecord_t *record, uint16_t qk_mo
         case KC_W:
         case VIM_W:
             set_visual_direction(V_FORWARD);
-            register_motion(qk_mods | VIM_W, record);
-            register_motion(qk_mods | VIM_W, record);
-            register_motion(qk_mods | VIM_B, record);
+            if (record->event.pressed) {
+              register_code16(qk_mods | VIM_W);
+            } else {
+              unregister_code16(qk_mods | VIM_W);
+              tap_code16(qk_mods | VIM_W);
+              tap_code16(qk_mods | VIM_B);
+            }
             return false;
         case KC_0:
         case VIM_0:

--- a/src/motions.c
+++ b/src/motions.c
@@ -66,6 +66,7 @@ bool process_motions(uint16_t keycode, const keyrecord_t *record, uint16_t qk_mo
             return false;
         case KC_0:
         case VIM_0:
+        case KC_CIRC:
             set_visual_direction(V_BACKWARD);
             register_motion(qk_mods | VIM_0, record);
             return false;

--- a/update-readme/Dockerfile
+++ b/update-readme/Dockerfile
@@ -1,0 +1,10 @@
+FROM qmkfm/qmk_firmware:latest
+
+ENV MY_KEYMAP_PATH=/qmk_firmware/keyboards/uno/keymaps/qmk-vim-update-readme
+
+WORKDIR /qmk_firmware
+
+COPY keymap $MY_KEYMAP_PATH
+COPY run.py /qmk_firmware/qmk_vim_update_readme.py
+
+CMD python3 qmk_vim_update_readme.py

--- a/update-readme/keymap/keymap.c
+++ b/update-readme/keymap/keymap.c
@@ -1,0 +1,21 @@
+#include QMK_KEYBOARD_H
+#include "qmk-vim/src/vim.h"
+
+enum keycodes {
+  QMK_VIM = SAFE_RANGE
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [0] = LAYOUT(QMK_VIM)
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  if (!process_vim_mode(keycode, record)) {
+    return false;
+  }
+  if (keycode == QMK_VIM && record->event.pressed) {
+    toggle_vim_mode();
+    return false;
+  }
+  return true;
+}

--- a/update-readme/keymap/rules.mk
+++ b/update-readme/keymap/rules.mk
@@ -1,0 +1,1 @@
+include keyboards/uno/keymaps/qmk-vim-update-readme/qmk-vim/rules.mk

--- a/update-readme/run.py
+++ b/update-readme/run.py
@@ -1,0 +1,52 @@
+import os
+import re
+import subprocess
+
+# Path to QMK keymap used for firmware size calculations
+MY_KEYMAP_PATH = os.getenv('MY_KEYMAP_PATH')
+README_PATH = os.path.join(MY_KEYMAP_PATH, 'qmk-vim/README.org')
+
+# Split readme into sections: before feature macros table, table itself, and after table
+BEFORE, MACROS, AFTER = 0, 1, 2
+lines = [[], [], []]
+position = BEFORE
+with open(README_PATH) as f:
+    for line in f:
+        if ((position == BEFORE and line.startswith('| ='))
+                or (position == MACROS and not line.startswith('|'))):
+            position += 1
+        lines[position].append(line)
+
+# Compile and parse output for firmware size
+def get_firmware_size():
+    process = subprocess.run(
+        ['qmk', 'compile', '-kb', 'uno', '-km', 'qmk-vim-update-readme'], capture_output=True)
+    matches = re.search(r'The firmware size is fine - (\d+)', process.stdout.decode('utf-8'))
+    return int(matches[1])
+
+# Determine firmware size without any macros defined
+baseline = get_firmware_size()
+
+# Iterate over rows in table
+for i in range(len(lines[MACROS])):
+    # Parse macro name
+    line = lines[MACROS][i]
+    cells = line.split('|')
+    macro = cells[1].strip('= ')
+    # Add macro to config
+    with open(os.path.join(MY_KEYMAP_PATH, 'config.h'), 'w') as f:
+        f.write(f'#define {macro}')
+    # Determine firmware size difference
+    size = get_firmware_size()
+    size_diff = baseline - size
+    if size_diff >= 0:
+        new_val_str = f' +{size_diff} B'
+    else:
+        new_val_str = f' {size_diff} B'
+    # Update table
+    cells[3] = new_val_str.ljust(len(cells[3]), ' ')
+    lines[MACROS][i] = '|'.join(cells)
+
+# Overwrite readme with new values
+with open(README_PATH, 'w') as f:
+    f.write(''.join(line for section in lines for line in section))


### PR DESCRIPTION
This is by far the most comprehensive and well-documented implementation of Vim keybindings for QMK that I've found - thanks a ton for open sourcing it!

I've been integrating it into my personal keymap over the past few days, and along the way I've added some functionality that I thought you and other users might be able to make use of as well:

#### Actions
* Added normal mode `s` - change the character to the right of the cursor.
* Added normal mode `S` - change the line (synonym for `cc`).
* Added visual and visual line mode `s` - change selection (synonym for `c`).
* Added visual and visual line mode `x` - delete selection (synonym for `d`).
* Added normal mode `X` - delete the character to the left of the cursor.
* Added `W`, `E`, and `B` synonyms for their lowercase equivalents, as well as `^` for `0`.
* Fixed redo action on Mac - this was originally mapped to `LCMD(KC_Y)`, but as far as I can tell, `LCMD(LSFT(KC_Z))` is more commonly used.

#### Motions
* Changed `w` motion to skip to beginning of next word by sending `VMOTION(KC_RIGHT)`, then tapping `VMOTION(KC_RIGHT)`, `VMOTION(KC_LEFT)` on release if enabled with `VIM_W_BEGINNING_OF_WORD` macro.

#### User hooks 
* Fixed existing `process_normal_mode_user` and `process_visual_mode_user` hooks - they weren't actually being called by their corresponding non-`_user` functions like `process_insert_mode_user` was.
* Added `process_visual_line_mode_user` hook, as keybindings defined in `process_visual_mode_user` were not being processed in visual line mode.
* Added `insert_mode_user`, `normal_mode_user`, `visual_mode_user`, and `visual_line_mode_user` hooks, which are called upon entering the relevant mode, to allow users to set custom state like RGB lighting layer indicators (see [my keymap](https://github.com/t33chong/qmk_firmware/blob/t33chong/users/t33chong/t33chong.c) for example use cases).

#### Readme
* Updated docs to reflect the aforementioned changes.
* Added instructions for configuration at the [userspace](https://beta.docs.qmk.fm/using-qmk/software-features/feature_userspace) level.
* Added a Python script + Dockerfile that contributors can use to update the table of firmware sizes for each feature macro automatically.

Caveat: I haven't written a whole lot of C, so there might be better ways to accomplish some of the things I've added here. Please scrutinize, be picky and don't hold back - your feedback will keep this codebase excellent and make me a better C programmer!

It's also entirely possible that I may have overlooked certain careful considerations you've made and introduced unexpected behavior; for example, I noticed that the readme explicitly mentioned that the `x` action had only been implemented in normal mode. If there was a good reason you originally left it out of the visual modes, and I've unwittingly broken something, please let me know! Similarly, I only tested this on macOS, so I can't confirm whether my changes to the various actions and motions work on other operating systems.

Finally, if there's anything here that doesn't fit with your vision for the project, or that you think might not have broad appeal among potential users, I'm more than happy either to put it behind an optional feature flag (i.e. a `#define` in `config.h`) or to move it to my personal keymap/userspace. One thing I suspect might fit into this category is my change to the `w` motion, since the sequence of motions it's composed of adds a bit of cursor flicker (at least on my system), which admittedly could be distracting.