### PR TITLE
Fix visual text objects

### DIFF
--- a/README.org
+++ b/README.org
@@ -20,8 +20,9 @@
 - [[#configuration][Configuration]]
   - [[#setup][Setup]]
   - [[#adding-keybinds][Adding Keybinds]]
+  - [[#setting-custom-state][Setting Custom State]]
   - [[#mac-support][Mac Support]]
-  - [[#displaying-modes][Displaying Modes]]
+  -  [[#displaying-modes][Displaying Modes]]
 - [[#contributing][Contributing]]
   - [[#updating-readme-firmware-sizes][Updating Readme Firmware Sizes]]
 
@@ -150,7 +151,7 @@ Once you hit ~.~ it goes through the recorded keys until it hits normal mode aga
 The default size of the recorded keys buffer is =64=, but can be modified with the =VIM_REPEAT_BUF_SIZE= macro.
 
 *** W Motions
-If the =VIM_W_BEGINNING_OF_WORD= macro is defined, the ~w~ and ~W~ motions (which are synonymous) will skip to the beginning of the next word by sending LCTL + RIGHT and then tapping LCTL + RIGHT, LCTL + LEFT on release. Otherwise, their default behavior is to imitate the ~e~ and ~E~ motions by sending LCTL + RIGHT. Note that enabling this feature currently causes unexpected side effects with actions such as ~cw~ and ~dw~, as well as those involving ~i~ and ~a~ text objects such as ~viw~ and ~vaw~ ([[https://github.com/andrewjrae/qmk-vim/pull/1#discussion_r650416367][context]]).
+If the =VIM_W_BEGINNING_OF_WORD= macro is defined, the ~w~ and ~W~ motions (which are synonymous) will skip to the beginning of the next word by sending LCTL + RIGHT and then tapping LCTL + RIGHT, LCTL + LEFT on release. Otherwise, their default behavior is to imitate the ~e~ and ~E~ motions by sending LCTL + RIGHT. Note that enabling this feature currently causes unexpected side effects with actions such as ~cw~ and ~dw~, where the ~w~ motion acts like an ~e~ motion  ([[https://github.com/andrewjrae/qmk-vim/pull/1#discussion_r650416367][context]]).
 
 * Configuration
 ** Setup

--- a/src/actions.c
+++ b/src/actions.c
@@ -3,10 +3,6 @@
 #include "process_func.h"
 
 
-#if defined (VIM_I_TEXT_OBJECTS) || defined (VIM_A_TEXT_OBJECTS)
-#define _VIM_TEXT_OBJECTS
-#endif
-
 // Function pointer type for executing actions
 typedef void (*action_func_t)(void);
 

--- a/src/actions.h
+++ b/src/actions.h
@@ -2,6 +2,11 @@
 
 #include "motions.h"
 
+// If either of the text objects are defined, define this macro for both
+#if defined (VIM_I_TEXT_OBJECTS) || defined (VIM_A_TEXT_OBJECTS)
+#define _VIM_TEXT_OBJECTS
+#endif
+
 // Define a custom variable for the common shortcut modifier
 // ie on MAC, CMD + C is copy, but on Windows/Linux it's CTRL + C
 // This should be used whenever using one of these shortcuts

--- a/src/modes.c
+++ b/src/modes.c
@@ -242,7 +242,7 @@ bool process_visual_mode(uint16_t keycode, const keyrecord_t *record) {
     if (!process_motions(keycode, record, QK_LSFT)) {
         return false;
     }
-#ifdef VIM_TEXT_OBJECTS
+#ifdef _VIM_TEXT_OBJECTS
     if (!process_text_objects(keycode, record)) {
         return false;
     }


### PR DESCRIPTION
@t33chong turns out I'm a big dummy and didn't realize I had changed the macro that defines text objects for the visual mode, so it wasn't even entering the text object function when I was trying to use `viw`, oops!

Turns out the word motion is not as broken as I thought, it's just `dw` etc that act like `de` that's still broken. But either way I think it's still probably best under a macro for now. 