### PR TITLE
Allow mac support to be turned on and off at runtime

### DIFF
--- a/README.org
+++ b/README.org
@@ -160,7 +160,7 @@ In an effort to reduce the size overhead of the project, any extra features can 
 |---------------------------+-----------------------------------------------------------------------------------------------------------------------------------+-------------------|
 | =NO_VISUAL_MODE=          | Disables the normal visual mode.                                                                                                  | +256 B            |
 | =NO_VISUAL_LINE_MODE=     | Disables the normal visual line mode.                                                                                             | +336 B            |
-| =BETTER_VISUAL_MODE=      | Makes the visual modes much more vim like, see [[#visual-line-mode][visual_line_mode()]] for details.                             | -174 B            |
+| =BETTER_VISUAL_MODE=      | Makes the visual modes much more vim like, see [[#visual-line-mode][visual_line_mode()]] for details.                             | -172 B            |
 | =VIM_I_TEXT_OBJECTS=      | Adds the ~i~ text objects, which adds the ~iw~ and ~ig~ text objects, see [[#text-objects][text objects]] for details.            | -122 B            |
 | =VIM_A_TEXT_OBJECTS=      | Adds the ~a~ text objects, which adds the ~aw~ and ~ag~ text objects.                                                             | -138 B            |
 | =VIM_G_MOTIONS=           | Adds ~gg~ and ~G~ motions, which only work in some programs.                                                                      | -116 B            |
@@ -168,10 +168,10 @@ In an effort to reduce the size overhead of the project, any extra features can 
 | =VIM_PASTE_BEFORE=        | Adds the ~P~ command.                                                                                                             | -60 B             |
 | =VIM_REPLACE=             | Adds the ~r~ command.                                                                                                             | -76 B             |
 | =VIM_DOT_REPEAT=          | Adds the ~.~ command, allowing you to repeat actions, see [[#dot-repeat][dot repeat]] for details.                                | -232 B            |
-| =VIM_W_BEGINNING_OF_WORD= | Makes the ~w~ and ~W~ motions skip to the beginning of the next word, see [[#w-motions][W motions]] for details.                  | -108 B            |
-| =VIM_NUMBERED_JUMPS=      | Adds the ability to do numbered motions, ie ~10j~ or ~5w~, be wary of large numbers however, as they can freeze up your keyboard. | -540 B            |
+| =VIM_W_BEGINNING_OF_WORD= | Makes the ~w~ and ~W~ motions skip to the beginning of the next word, see [[#w-motions][W motions]] for details.                  | -104 B            |
+| =VIM_NUMBERED_JUMPS=      | Adds the ability to do numbered motions, ie ~10j~ or ~5w~, be wary of large numbers however, as they can freeze up your keyboard. | -544 B            |
 | =ONESHOT_VIM=             | Enables running vim in "oneshot" mode, see [[#oneshot-vim][oneshot vim]] for details.                                             | -76 B             |
-| =VIM_FOR_ALL=             | Adds the ability to toggle Mac support on and off at runtime, rather than only at compile time.                                   | -450 B            |
+| =VIM_FOR_ALL=             | Adds the ability to toggle Mac support on and off at runtime, rather than only at compile time.                                   | -456 B            |
 
 *** Text Objects
 Unfortunately there is really no way to implement text objects properly,

--- a/README.org
+++ b/README.org
@@ -171,7 +171,7 @@ In an effort to reduce the size overhead of the project, any extra features can 
 | =VIM_W_BEGINNING_OF_WORD= | Makes the ~w~ and ~W~ motions skip to the beginning of the next word, see [[#w-motions][W motions]] for details.                  | -108 B            |
 | =VIM_NUMBERED_JUMPS=      | Adds the ability to do numbered motions, ie ~10j~ or ~5w~, be wary of large numbers however, as they can freeze up your keyboard. | -540 B            |
 | =ONESHOT_VIM=             | Enables running vim in "oneshot" mode, see [[#oneshot-vim][oneshot vim]] for details.                                             | -76 B             |
-| =VIM_FOR_ALL=             | Adds the ability to toggle Mac support on and off at runtime, rather than only at compile time.                                   | -422 B            |
+| =VIM_FOR_ALL=             | Adds the ability to toggle Mac support on and off at runtime, rather than only at compile time.                                   | -450 B            |
 
 *** Text Objects
 Unfortunately there is really no way to implement text objects properly,

--- a/README.org
+++ b/README.org
@@ -171,6 +171,7 @@ In an effort to reduce the size overhead of the project, any extra features can 
 | =VIM_W_BEGINNING_OF_WORD= | Makes the ~w~ and ~W~ motions skip to the beginning of the next word, see [[#w-motions][W motions]] for details.                  | -108 B            |
 | =VIM_NUMBERED_JUMPS=      | Adds the ability to do numbered motions, ie ~10j~ or ~5w~, be wary of large numbers however, as they can freeze up your keyboard. | -540 B            |
 | =ONESHOT_VIM=             | Enables running vim in "oneshot" mode, see [[#oneshot-vim][oneshot vim]] for details.                                             | -76 B             |
+| =VIM_FOR_ALL=             | Adds the ability to toggle Mac support on and off at runtime, rather than only at compile time.                                   | -422 B            |
 
 *** Text Objects
 Unfortunately there is really no way to implement text objects properly,
@@ -361,6 +362,20 @@ guess there are some issues.
 
 If you are a Mac user and do encounter issues, feel free to put up a PR or an
 issue.
+
+If you intend to use your keyboard with both Mac and Windows or Linux computers, you can set the =VIM_FOR_ALL= macro in
+your config.h. This will allow you to use the following functions in your keymap.c to switch between Mac support mode
+and non-Mac support mode:
+#+begin_src C
+void enable_vim_for_mac(void);
+void disable_vim_for_mac(void);
+void toggle_vim_for_mac(void);
+bool vim_for_mac_enabled(void);
+#+end_src
+=VIM_FOR_ALL= overrides the behavior of =VIM_FOR_MAC=.
+
+By default the keyboard will start in non-Mac support mode, but if =VIM_FOR_ALL= and =VIM_FOR_MAC= are both defined the
+keyboard will start in Mac support mode.
 
 **  Displaying Modes
 To help remind you that you have vim mode enabled, there are two functions

--- a/rules.mk
+++ b/rules.mk
@@ -1,4 +1,5 @@
 # note that the order is important here
+SRC += qmk-vim/src/mac_mode.c
 SRC += qmk-vim/src/process_func.c
 SRC += qmk-vim/src/numbered_actions.c
 SRC += qmk-vim/src/motions.c

--- a/src/actions.h
+++ b/src/actions.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "mac_mode.h"
 #include "motions.h"
 
 // If either of the text objects are defined, define this macro for both
@@ -10,13 +11,9 @@
 // Define a custom variable for the common shortcut modifier
 // ie on MAC, CMD + C is copy, but on Windows/Linux it's CTRL + C
 // This should be used whenever using one of these shortcuts
-#ifdef VIM_FOR_MAC
-#define VCMD LCMD
-#define VIM_REDO VCMD(LSFT(KC_Z))
-#else
-#define VCMD LCTL
-#define VIM_REDO VCMD(KC_Y)
-#endif
+
+#define VCMD(kc) VIM_MAC_NOMAC(LCMD(kc), LCTL(kc))
+#define VIM_REDO VIM_MAC_NOMAC(VCMD(LSFT(KC_Z)), VCMD(KC_Y))
 
 // These + VIM_REDO (defined above) are the main keys for each vim core vim action
 #define VIM_CHANGE KC_DEL

--- a/src/mac_mode.c
+++ b/src/mac_mode.c
@@ -2,6 +2,7 @@
 
 #ifdef VIM_FOR_ALL
 
+// When VIM_FOR_ALL is enabled, we allow the user to choose if mac support is enabled at startup or not
 #ifdef VIM_FOR_MAC
 bool vim_for_mac = true;
 #else

--- a/src/mac_mode.c
+++ b/src/mac_mode.c
@@ -1,0 +1,11 @@
+#include "mac_mode.h"
+
+#ifdef VIM_FOR_ALL
+
+#ifdef VIM_FOR_MAC
+bool vim_for_mac = true;
+#else
+bool vim_for_mac = false;
+#endif
+
+#endif

--- a/src/mac_mode.h
+++ b/src/mac_mode.h
@@ -11,16 +11,29 @@ extern bool vim_for_mac;
 // expressions, which means they cannot be used in a case statement
 // In order to get around this restriction we can duplicate the switch statement
 // and force our keycode to evaluate as a constant expression in each
-#define VIM_REDUCE_MAC_NOMAC_TO_CONST(body) { \
-    if(vim_for_mac) { const bool vim_for_mac = true; body } \
-    else { const bool vim_for_mac = false; body } \
-}
+#define VIM_REDUCE_MAC_NOMAC_TO_CONST(body) do { \
+    if(vim_for_mac) { \
+        const bool vim_for_mac = true; \
+        body \
+    } \
+    else { \
+        const bool vim_for_mac = false; \
+        body \
+    } \
+} while (0)
 
-#elif defined(VIM_FOR_MAC)
+#else
+
+#ifdef VIM_FOR_MAC
 #define VIM_MAC_NOMAC(a, b) (a)
 
 #else
 #define VIM_MAC_NOMAC(a, b) (b)
+#endif
+
+#define VIM_REDUCE_MAC_NOMAC_TO_CONST(body) do { \
+    body \
+} while(0)
 
 #endif
 

--- a/src/mac_mode.h
+++ b/src/mac_mode.h
@@ -7,9 +7,9 @@
 extern bool vim_for_mac;
 
 #define VIM_MAC_NOMAC(a, b) (vim_for_mac ? (a) : (b))
-// The keycodes produced by this VIM_MAC_NOMAC are not constants, so they cannot be used in a case statement.
+// The keycodes produced by this VIM_MAC_NOMAC are not constants, so they cannot be used in a case statement
 // In order to get around this, we can duplicate the switch statement
-// and force our keycode to evaluate as a constant expression in each.
+// and force our keycode to evaluate as a constant expression in each
 #define VIM_REDUCE_NOMAC_MAC_TO_CONST(body) { \
     if(vim_for_mac) { const bool vim_for_mac = true; body } \
     else { const bool vim_for_mac = false; body } \

--- a/src/mac_mode.h
+++ b/src/mac_mode.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include QMK_KEYBOARD_H
+
+#ifdef VIM_FOR_ALL
+
+extern bool vim_for_mac;
+
+#define VIM_MAC_NOMAC(a, b) (vim_for_mac ? (a) : (b))
+// The keycodes produced by this VIM_MAC_NOMAC are not constants, so they cannot be used in a case statement.
+// In order to get around this, we can duplicate the switch statement
+// and force our keycode to evaluate as a constant expression in each.
+#define VIM_REDUCE_NOMAC_MAC_TO_CONST(body) { \
+    if(vim_for_mac) { const bool vim_for_mac = true; body } \
+    else { const bool vim_for_mac = false; body } \
+}
+
+#elif defined(VIM_FOR_MAC)
+#define VIM_MAC_NOMAC(a, b) (a)
+
+#else
+#define VIM_MAC_NOMAC(a, b) (b)
+
+#endif
+

--- a/src/mac_mode.h
+++ b/src/mac_mode.h
@@ -7,10 +7,11 @@
 extern bool vim_for_mac;
 
 #define VIM_MAC_NOMAC(a, b) (vim_for_mac ? (a) : (b))
-// The keycodes produced by this VIM_MAC_NOMAC are not constants, so they cannot be used in a case statement
-// In order to get around this, we can duplicate the switch statement
+// The results of this implimentation of VIM_MAC_NOMAC are not constant
+// expressions, which means they cannot be used in a case statement
+// In order to get around this restriction we can duplicate the switch statement
 // and force our keycode to evaluate as a constant expression in each
-#define VIM_REDUCE_NOMAC_MAC_TO_CONST(body) { \
+#define VIM_REDUCE_MAC_NOMAC_TO_CONST(body) { \
     if(vim_for_mac) { const bool vim_for_mac = true; body } \
     else { const bool vim_for_mac = false; body } \
 }

--- a/src/motions.c
+++ b/src/motions.c
@@ -31,7 +31,7 @@ void register_motion(uint16_t keycode, const keyrecord_t *record) {
 bool process_motions(uint16_t keycode, const keyrecord_t *record, uint16_t qk_mods) {
 #ifdef VIM_FOR_ALL
     // This macro duplicates the code inside
-    // Calling it on only a subset of the larger switch statement saves about 200bytes
+    // Calling it on only a subset of the larger switch statement saves about 200 bytes
     VIM_REDUCE_NOMAC_MAC_TO_CONST(
         switch (keycode) {
            case VIM_B: keycode = KC_B;

--- a/src/motions.c
+++ b/src/motions.c
@@ -34,10 +34,18 @@ bool process_motions(uint16_t keycode, const keyrecord_t *record, uint16_t qk_mo
     // Calling it on only a subset of the larger switch statement saves some space
     VIM_REDUCE_MAC_NOMAC_TO_CONST(
         switch (keycode) {
-           case VIM_B: keycode = KC_B;
-           case VIM_W: keycode = KC_W;
-           case VIM_0: keycode = KC_0;
-           case VIM_DLR: keycode = KC_DLR;
+           case VIM_B:
+               keycode = KC_B;
+               break;
+           case VIM_W:
+               keycode = KC_W;
+               break;
+           case VIM_0:
+               keycode = KC_0;
+               break;
+           case VIM_DLR:
+               keycode = KC_DLR;
+               break;
         }
     )
 #endif

--- a/src/motions.c
+++ b/src/motions.c
@@ -31,8 +31,8 @@ void register_motion(uint16_t keycode, const keyrecord_t *record) {
 bool process_motions(uint16_t keycode, const keyrecord_t *record, uint16_t qk_mods) {
 #ifdef VIM_FOR_ALL
     // This macro duplicates the code inside
-    // Calling it on only a subset of the larger switch statement saves about 200 bytes
-    VIM_REDUCE_NOMAC_MAC_TO_CONST(
+    // Calling it on only a subset of the larger switch statement saves some space
+    VIM_REDUCE_MAC_NOMAC_TO_CONST(
         switch (keycode) {
            case VIM_B: keycode = KC_B;
            case VIM_W: keycode = KC_W;

--- a/src/motions.c
+++ b/src/motions.c
@@ -1,3 +1,4 @@
+#include "mac_mode.h"
 #include "motions.h"
 #include "numbered_actions.h"
 
@@ -28,6 +29,18 @@ void register_motion(uint16_t keycode, const keyrecord_t *record) {
 }
 
 bool process_motions(uint16_t keycode, const keyrecord_t *record, uint16_t qk_mods) {
+#ifdef VIM_FOR_ALL
+    // This macro duplicates the code inside
+    // Calling it on only a subset of the larger switch statement saves about 200bytes
+    VIM_REDUCE_NOMAC_MAC_TO_CONST(
+        switch (keycode) {
+           case VIM_B: keycode = KC_B;
+           case VIM_W: keycode = KC_W;
+           case VIM_0: keycode = KC_0;
+           case VIM_DLR: keycode = KC_DLR;
+        }
+    )
+#endif
     DO_NUMBERED_ACTION(
         switch (keycode) {
         case KC_H:
@@ -51,13 +64,17 @@ bool process_motions(uint16_t keycode, const keyrecord_t *record, uint16_t qk_mo
             register_motion(qk_mods | VIM_L, record);
             break;
         case KC_B:
+#ifndef VIM_FOR_ALL
         case VIM_B:
+#endif
         case LSFT(KC_B):
             set_visual_direction(V_BACKWARD);
             register_motion(qk_mods | VIM_B, record);
             break;
         case KC_W:
+#ifndef VIM_FOR_ALL
         case VIM_W:
+#endif
         case LSFT(KC_W):
 #ifdef VIM_W_BEGINNING_OF_WORD
             set_visual_direction(V_FORWARD);
@@ -75,13 +92,17 @@ bool process_motions(uint16_t keycode, const keyrecord_t *record, uint16_t qk_mo
             register_motion(qk_mods | VIM_E, record);
             break;
         case KC_0:
+#ifndef VIM_FOR_ALL
         case VIM_0:
+#endif
         case KC_CIRC: // ^
             set_visual_direction(V_BACKWARD);
             register_motion(qk_mods | VIM_0, record);
             break;
         case KC_DLR:
+#ifndef VIM_FOR_ALL
         case VIM_DLR: // $
+#endif
             set_visual_direction(V_FORWARD);
             register_motion(qk_mods | VIM_DLR, record);
             break;

--- a/src/motions.c
+++ b/src/motions.c
@@ -29,8 +29,7 @@ void register_motion(uint16_t keycode, const keyrecord_t *record) {
 }
 
 bool process_motions(uint16_t keycode, const keyrecord_t *record, uint16_t qk_mods) {
-#ifdef VIM_FOR_ALL
-    // This macro duplicates the code inside
+    // This macro duplicates the code inside if VIM_FOR_ALL is enabled
     // Calling it on only a subset of the larger switch statement saves some space
     VIM_REDUCE_MAC_NOMAC_TO_CONST(
         switch (keycode) {
@@ -47,8 +46,7 @@ bool process_motions(uint16_t keycode, const keyrecord_t *record, uint16_t qk_mo
                keycode = KC_DLR;
                break;
         }
-    )
-#endif
+    );
     DO_NUMBERED_ACTION(
         switch (keycode) {
         case KC_H:
@@ -72,17 +70,11 @@ bool process_motions(uint16_t keycode, const keyrecord_t *record, uint16_t qk_mo
             register_motion(qk_mods | VIM_L, record);
             break;
         case KC_B:
-#ifndef VIM_FOR_ALL
-        case VIM_B:
-#endif
         case LSFT(KC_B):
             set_visual_direction(V_BACKWARD);
             register_motion(qk_mods | VIM_B, record);
             break;
         case KC_W:
-#ifndef VIM_FOR_ALL
-        case VIM_W:
-#endif
         case LSFT(KC_W):
 #ifdef VIM_W_BEGINNING_OF_WORD
             set_visual_direction(V_FORWARD);
@@ -100,17 +92,11 @@ bool process_motions(uint16_t keycode, const keyrecord_t *record, uint16_t qk_mo
             register_motion(qk_mods | VIM_E, record);
             break;
         case KC_0:
-#ifndef VIM_FOR_ALL
-        case VIM_0:
-#endif
         case KC_CIRC: // ^
             set_visual_direction(V_BACKWARD);
             register_motion(qk_mods | VIM_0, record);
             break;
-        case KC_DLR:
-#ifndef VIM_FOR_ALL
-        case VIM_DLR: // $
-#endif
+        case KC_DLR: // $
             set_visual_direction(V_FORWARD);
             register_motion(qk_mods | VIM_DLR, record);
             break;

--- a/src/motions.h
+++ b/src/motions.h
@@ -6,16 +6,15 @@
 // Define a custom variable for the common motion shortcut modifier
 // ie on MAC, OPT + RIGHT is forward word, but on Windows/Linux it's CTRL + RIGHT
 // This should be used whenever using one of these shortcuts
-
 #define VMOTION(kc) VIM_MAC_NOMAC(LOPT(kc), LCTL(kc))
 
 #define VIM_0 VIM_MAC_NOMAC(LCMD(KC_LEFT), KC_HOME)
-#define VIM_HOME() VIM_MAC_NOMAC(tap_code16(VIM_0), tap_code(VIM_0))
+#define VIM_HOME() VIM_MAC_NOMAC(tap_code16(VIM_0), tap_code(VIM_0));
 #define VIM_SHIFT_HOME() tap_code16(LSFT(VIM_0));
 
 #define VIM_DLR VIM_MAC_NOMAC(LCMD(KC_RIGHT), KC_END)
-#define VIM_END() VIM_MAC_NOMAC(tap_code16(VIM_DLR), tap_code(VIM_DLR))
-#define VIM_SHIFT_END() tap_code16(LSFT(VIM_DLR))
+#define VIM_END() VIM_MAC_NOMAC(tap_code16(VIM_DLR), tap_code(VIM_DLR));
+#define VIM_SHIFT_END() tap_code16(LSFT(VIM_DLR));
 
 // The vim motions keys supported by single keystrokes/chords
 #define VIM_H KC_LEFT

--- a/src/motions.h
+++ b/src/motions.h
@@ -1,34 +1,21 @@
 #pragma once
 
 #include QMK_KEYBOARD_H
+#include "mac_mode.h"
 
 // Define a custom variable for the common motion shortcut modifier
 // ie on MAC, OPT + RIGHT is forward word, but on Windows/Linux it's CTRL + RIGHT
 // This should be used whenever using one of these shortcuts
-#ifdef VIM_FOR_MAC
-#define VMOTION LOPT
 
-#define VIM_0 LCMD(KC_LEFT)
-#define VIM_HOME() tap_code16(VIM_0);
+#define VMOTION(kc) VIM_MAC_NOMAC(LOPT(kc), LCTL(kc))
+
+#define VIM_0 VIM_MAC_NOMAC(LCMD(KC_LEFT), KC_HOME)
+#define VIM_HOME() VIM_MAC_NOMAC(tap_code16(VIM_0), tap_code(VIM_0))
 #define VIM_SHIFT_HOME() tap_code16(LSFT(VIM_0));
 
-#define VIM_DLR LCMD(KC_RIGHT)
-#define VIM_END() tap_code16(VIM_DLR);
-#define VIM_SHIFT_END() tap_code16(LSFT(VIM_DLR));
-
-#else // Windows / Linux
-
-#define VMOTION LCTL
-
-#define VIM_0 KC_HOME
-#define VIM_HOME() tap_code(VIM_0);
-#define VIM_SHIFT_HOME() tap_code16(LSFT(VIM_0));
-
-#define VIM_DLR KC_END
-#define VIM_END() tap_code(VIM_DLR);
-#define VIM_SHIFT_END() tap_code16(LSFT(VIM_DLR));
-
-#endif
+#define VIM_DLR VIM_MAC_NOMAC(LCMD(KC_RIGHT), KC_END)
+#define VIM_END() VIM_MAC_NOMAC(tap_code16(VIM_DLR), tap_code(VIM_DLR))
+#define VIM_SHIFT_END() tap_code16(LSFT(VIM_DLR))
 
 // The vim motions keys supported by single keystrokes/chords
 #define VIM_H KC_LEFT

--- a/src/vim.c
+++ b/src/vim.c
@@ -23,6 +23,26 @@
 extern process_func_t process_func;
 
 static bool vim_enabled = false;
+
+#ifdef VIM_FOR_ALL
+// Check to see if mac mode is enabled
+bool vim_for_mac_enabled(void) {
+    return vim_for_mac;
+}
+// Enable mac mode
+void enable_vim_for_mac(void) {
+    vim_for_mac = true;
+}
+// Disable mac mode
+void disable_vim_for_mac(void) {
+    vim_for_mac = false;
+}
+// Toggle mac mode
+void toggle_vim_for_mac(void) {
+    vim_for_mac = !vim_for_mac;
+}
+#endif
+
 // Check to see if vim mode is enabled
 bool vim_mode_enabled(void) {
     return vim_enabled;

--- a/src/vim.h
+++ b/src/vim.h
@@ -34,5 +34,15 @@ void start_oneshot_vim(void);
 void stop_oneshot_vim(void);
 #endif
 
+#ifdef VIM_FOR_ALL
+// Check to see if mac mode is enabled
+bool vim_for_mac_enabled(void);
+// Enable mac mode
+void enable_vim_for_mac(void);
+// Disable mac mode
+void disable_vim_for_mac(void);
+// Toggle mac mode
+void toggle_vim_for_mac(void);
+#endif
 // Process keycode for vim mode
 bool process_vim_mode(uint16_t keycode, const keyrecord_t *record);


### PR DESCRIPTION
I've implemented a feature that allows mac support to be turned on and off at runtime. I'm currently using this on my Keychron q2, and I have the toggle hooked up to the dip switch on the back. It seems to work pretty well in my testing.