### PR TITLE
Implement Escape Passthrough feature

### DIFF
--- a/README.org
+++ b/README.org
@@ -172,6 +172,7 @@ In an effort to reduce the size overhead of the project, any extra features can 
 | =VIM_NUMBERED_JUMPS=      | Adds the ability to do numbered motions, ie ~10j~ or ~5w~, be wary of large numbers however, as they can freeze up your keyboard. | -544 B            |
 | =ONESHOT_VIM=             | Enables running vim in "oneshot" mode, see [[#oneshot-vim][oneshot vim]] for details.                                             | -76 B             |
 | =VIM_FOR_ALL=             | Adds the ability to toggle Mac support on and off at runtime, rather than only at compile time.                                   | -456 B            |
+| =VIM_ESCAPE_PASSTHROUGH=  | Adds the ability to send escape character while vim mode is active.                                                               |    0 B            |
 
 *** Text Objects
 Unfortunately there is really no way to implement text objects properly,

--- a/README.org
+++ b/README.org
@@ -173,7 +173,7 @@ In an effort to reduce the size overhead of the project, any extra features can 
 | =VIM_NUMBERED_JUMPS=      | Adds the ability to do numbered motions, ie ~10j~ or ~5w~, be wary of large numbers however, as they can freeze up your keyboard. | -472 B            |
 | =ONESHOT_VIM=             | Enables running vim in "oneshot" mode, see [[#oneshot-vim][oneshot vim]] for details.                                             | -84 B             |
 | =VIM_FOR_ALL=             | Adds the ability to toggle Mac support on and off at runtime, rather than only at compile time.                                   | -600 B            |
-| =ESCAPE_PASSTHROUGH=      | Allows passthrough of the `Escape` key in Normal mode while retaining its Insert mode behavior.                                   | +0 B              |
+| =VIM_ESC_PASSTHROUGH=     | Allows passthrough of the `Escape` key in Normal mode while retaining its Insert mode behavior.                                   | -8 B              |
 
 *** Text Objects
 Unfortunately there is really no way to implement text objects properly,
@@ -253,7 +253,7 @@ context, such as interacting with external tools or systems. Without this featur
 all `Escape` presses are intercepted, making it impossible to send the keycode
 without disabling Vim mode entirely.
 
-To enable this feature, add the `ESCAPE_PASSTHROUGH` macro to your `config.h`.
+To enable this feature, add the `VIM_ESC_PASSTHROUGH` macro to your `config.h`.
 
 * Configuration
 ** Setup
@@ -426,5 +426,5 @@ to the table manually by running the following commands in the root directory of
 repository (it may take a few minutes, since it recompiles for each feature in the table):
 #+begin_src bash
 docker build -t qmk-vim-update-readme update-readme
-docker run -v $PWD:/qmk_firmware/keyboards/uno/keymaps/qmk-vim-update-readme/qmk-vim qmk-vim-update-readme
+docker run -v $PWD:/qmk_firmware/keyboards/keyhive/uno/keymaps/qmk-vim-update-readme/qmk-vim qmk-vim-update-readme
 #+end_src

--- a/README.org
+++ b/README.org
@@ -19,6 +19,7 @@
     - [[#w-motions][W Motions]]
     - [[#numbered-jumps][Numbered Jumps]]
     - [[#oneshot-vim][Oneshot Vim]]
+    - [[#escape-passthrough][Escape Passthrough]]
 - [[#configuration][Configuration]]
   - [[#setup][Setup]]
   - [[#adding-keybinds][Adding Keybinds]]
@@ -158,21 +159,21 @@ visual selection a line above when moving downwards.  Of course
 In an effort to reduce the size overhead of the project, any extra features can be enabled and disabled using macros in your config.h.
 | Macro                     | Features Enabled/Disabled                                                                                                         | Bytes (gcc 8.3.0) |
 |---------------------------+-----------------------------------------------------------------------------------------------------------------------------------+-------------------|
-| =NO_VISUAL_MODE=          | Disables the normal visual mode.                                                                                                  | +256 B            |
-| =NO_VISUAL_LINE_MODE=     | Disables the normal visual line mode.                                                                                             | +336 B            |
+| =NO_VISUAL_MODE=          | Disables the normal visual mode.                                                                                                  | +252 B            |
+| =NO_VISUAL_LINE_MODE=     | Disables the normal visual line mode.                                                                                             | +332 B            |
 | =BETTER_VISUAL_MODE=      | Makes the visual modes much more vim like, see [[#visual-line-mode][visual_line_mode()]] for details.                             | -172 B            |
-| =VIM_I_TEXT_OBJECTS=      | Adds the ~i~ text objects, which adds the ~iw~ and ~ig~ text objects, see [[#text-objects][text objects]] for details.            | -122 B            |
-| =VIM_A_TEXT_OBJECTS=      | Adds the ~a~ text objects, which adds the ~aw~ and ~ag~ text objects.                                                             | -138 B            |
-| =VIM_G_MOTIONS=           | Adds ~gg~ and ~G~ motions, which only work in some programs.                                                                      | -116 B            |
-| =VIM_COLON_CMDS=          | Adds the colon command state, but only the ~w~ and ~q~ commands are supported (can be in combination).                            | -72 B             |
+| =VIM_I_TEXT_OBJECTS=      | Adds the ~i~ text objects, which adds the ~iw~ and ~ig~ text objects, see [[#text-objects][text objects]] for details.            | -120 B            |
+| =VIM_A_TEXT_OBJECTS=      | Adds the ~a~ text objects, which adds the ~aw~ and ~ag~ text objects.                                                             | -136 B            |
+| =VIM_G_MOTIONS=           | Adds ~gg~ and ~G~ motions, which only work in some programs.                                                                      | -118 B            |
+| =VIM_COLON_CMDS=          | Adds the colon command state, but only the ~w~ and ~q~ commands are supported (can be in combination).                            | -78 B             |
 | =VIM_PASTE_BEFORE=        | Adds the ~P~ command.                                                                                                             | -60 B             |
-| =VIM_REPLACE=             | Adds the ~r~ command.                                                                                                             | -76 B             |
-| =VIM_DOT_REPEAT=          | Adds the ~.~ command, allowing you to repeat actions, see [[#dot-repeat][dot repeat]] for details.                                | -232 B            |
-| =VIM_W_BEGINNING_OF_WORD= | Makes the ~w~ and ~W~ motions skip to the beginning of the next word, see [[#w-motions][W motions]] for details.                  | -104 B            |
-| =VIM_NUMBERED_JUMPS=      | Adds the ability to do numbered motions, ie ~10j~ or ~5w~, be wary of large numbers however, as they can freeze up your keyboard. | -544 B            |
-| =ONESHOT_VIM=             | Enables running vim in "oneshot" mode, see [[#oneshot-vim][oneshot vim]] for details.                                             | -76 B             |
-| =VIM_FOR_ALL=             | Adds the ability to toggle Mac support on and off at runtime, rather than only at compile time.                                   | -456 B            |
-| =VIM_ESCAPE_PASSTHROUGH=  | Adds the ability to send escape character while vim mode is active.                                                               |    0 B            |
+| =VIM_REPLACE=             | Adds the ~r~ command.                                                                                                             | -80 B             |
+| =VIM_DOT_REPEAT=          | Adds the ~.~ command, allowing you to repeat actions, see [[#dot-repeat][dot repeat]] for details.                                | -236 B            |
+| =VIM_W_BEGINNING_OF_WORD= | Makes the ~w~ and ~W~ motions skip to the beginning of the next word, see [[#w-motions][W motions]] for details.                  | -98 B             |
+| =VIM_NUMBERED_JUMPS=      | Adds the ability to do numbered motions, ie ~10j~ or ~5w~, be wary of large numbers however, as they can freeze up your keyboard. | -472 B            |
+| =ONESHOT_VIM=             | Enables running vim in "oneshot" mode, see [[#oneshot-vim][oneshot vim]] for details.                                             | -84 B             |
+| =VIM_FOR_ALL=             | Adds the ability to toggle Mac support on and off at runtime, rather than only at compile time.                                   | -600 B            |
+| =ESCAPE_PASSTHROUGH=      | Allows passthrough of the `Escape` key in Normal mode while retaining its Insert mode behavior.                                   | +0 B              |
 
 *** Text Objects
 Unfortunately there is really no way to implement text objects properly,
@@ -241,6 +242,18 @@ Note that currently simple things like ~x~ and ~Y~ do not cause oneshot vim to e
 
 To enable this mode simply add the =ONESHOT_VIM= macro to your =config.h=.
 Then add some way to call the =start_oneshot_vim()= function.
+
+*** Escape Passthrough
+
+The Escape Passthrough feature modifies the behavior of the KC_ESC key in normal
+mode to allow it to send the keycode directly to the operating system.
+
+This feature is useful for workflows requiring the KC_ESC key outside of Neovim's
+context, such as interacting with external tools or systems. Without this feature,
+all `Escape` presses are intercepted, making it impossible to send the keycode
+without disabling Vim mode entirely.
+
+To enable this feature, add the `ESCAPE_PASSTHROUGH` macro to your `config.h`.
 
 * Configuration
 ** Setup
@@ -408,9 +421,9 @@ if (vim_mode_enabled()) {
 * Contributing
 ** Updating Readme Firmware Sizes
 If you'd like to submit a pull request, please update the [[#extra-features][table with the
-firmware sizes for each feature]]. This can be done automatically by running the
-following commands in the root directory of this repository (it may take a few
-minutes, since it recompiles for each feature in the table):
+firmware sizes for each feature]]. This can be done automatically after adding your feature
+to the table manually by running the following commands in the root directory of this
+repository (it may take a few minutes, since it recompiles for each feature in the table):
 #+begin_src bash
 docker build -t qmk-vim-update-readme update-readme
 docker run -v $PWD:/qmk_firmware/keyboards/uno/keymaps/qmk-vim-update-readme/qmk-vim qmk-vim-update-readme

--- a/src/modes.c
+++ b/src/modes.c
@@ -77,6 +77,13 @@ bool process_normal_mode(uint16_t keycode, const keyrecord_t *record) {
     #define NO_RECORD_ACTION()
 #endif
 
+#ifdef VIM_ESC_PASSTHROUGH
+    // Pass through Escape when already in normal mode
+    if (keycode == KC_ESC) {
+        return true;
+    }
+#endif
+
     // process numbers for numbered actions
 #ifdef VIM_NUMBERED_JUMPS
     if (!process_numbers(keycode, record)) {

--- a/update-readme/Dockerfile
+++ b/update-readme/Dockerfile
@@ -1,6 +1,6 @@
-FROM qmkfm/qmk_firmware:latest
+FROM jonz94/qmk_firmware:latest
 
-ENV MY_KEYMAP_PATH=/qmk_firmware/keyboards/uno/keymaps/qmk-vim-update-readme
+ENV MY_KEYMAP_PATH=/qmk_firmware/keyboards/keyhive/uno/keymaps/qmk-vim-update-readme
 
 WORKDIR /qmk_firmware
 

--- a/update-readme/keymap/rules.mk
+++ b/update-readme/keymap/rules.mk
@@ -1,1 +1,1 @@
-include keyboards/uno/keymaps/qmk-vim-update-readme/qmk-vim/rules.mk
+include keyboards/keyhive/uno/keymaps/qmk-vim-update-readme/qmk-vim/rules.mk

--- a/update-readme/run.py
+++ b/update-readme/run.py
@@ -20,7 +20,7 @@ with open(README_PATH) as f:
 # Compile and parse output for firmware size
 def get_firmware_size():
     process = subprocess.run(
-        ['qmk', 'compile', '-kb', 'uno', '-km', 'qmk-vim-update-readme'], capture_output=True)
+        ['qmk', 'compile', '-kb', 'keyhive/uno/rev2', '-km', 'qmk-vim-update-readme'], capture_output=True)
     matches = re.search(r'The firmware size is fine - (\d+)', process.stdout.decode('utf-8'))
     return int(matches[1])
 


### PR DESCRIPTION
I needed the ability to send Esc to the application I'm working in (specifically my browser, typing in a text area, but needing to de-focus it to activate vimium in the browser) and I wanted to do it without turning vim mode off. This just allows Escape to be sent in normal mode as it were a normal keyboard.

The majority of the work here was to update the feature size generator docker container.  The official QMK docker container was abandoned a long time ago and the KC_CAPS breaking changes that had been fixed here in the previous merge were causing a compilation error there. So I updated the docker image to what seems to be the new standard bearer and pointed to the new location of the uno's keymap.

Thank you for this package, you saved me from having to write it myself. I would have done a much worse job.